### PR TITLE
Improve day heading detection in diet output

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import re
+
 import streamlit as st
 from transformers import pipeline
 
@@ -42,9 +44,11 @@ Görev: Bu kişiye uygun 7 günlük bir diyet programı hazırla.
 
     # Sonucu daha okunabilir hale getir
     st.subheader("📝 Haftalık Diyet Önerisi")
+    day_heading_pattern = re.compile(r"^\s*(\d+\.?\s*)?(gün|day)\b", re.IGNORECASE)
+
     for line in text_output.split("\n"):
         if line.strip():
-            if any(day in line.lower() for day in ["gün", "day"]):
+            if day_heading_pattern.match(line):
                 st.markdown(f"### 📅 {line}")
             else:
                 st.markdown(f"- {line}")


### PR DESCRIPTION
## Summary
- import the `re` module and compile a pattern that matches only actual day headings
- use the regex to avoid misidentifying regular sentences that contain the word "gün" as headings

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c55ec2008329b0e943b3734cd24b